### PR TITLE
Don't process cmake config if external libs are not set (particularly he...

### DIFF
--- a/Common.cmake
+++ b/Common.cmake
@@ -13,8 +13,7 @@ find_path(EXTERNAL_LIBRARY_DIR "glew-1.9.0" HINTS /opt/local/Libraries PATHS $EN
 # TODO: Make EXTERNAL_LIBRARY_DIR detection optional, since users may not have their libraries
 # installed the same way we (Leap) do.
 if(EXTERNAL_LIBRARY_DIR STREQUAL "EXTERNAL_LIBRARY_DIR-NOTFOUND")
-    message(STATUS "External Library Directory not found, please specify a folder to look for external libraries")
-    return()
+    message( FATAL_ERROR "EXTERNAL_LIBRARY_DIR not found, please specify a folder to look for external libraries")
 endif()
 
 # CMAKE_PREFIX_PATH is the path used for searching by FIND_XXX(), with appropriate suffixes added.

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -1,3 +1,5 @@
+include(Common)
+
 # Root dependency
 find_package(Components REQUIRED)
 

--- a/source/VRIntro/CMakeLists.txt
+++ b/source/VRIntro/CMakeLists.txt
@@ -1,5 +1,3 @@
-include(Common)
-
 set(VRIntro_SOURCES
     main.cpp
     APIFrameSupplier.h

--- a/source/VRIntroLib/CMakeLists.txt
+++ b/source/VRIntroLib/CMakeLists.txt
@@ -1,5 +1,3 @@
-include(Common)
-
 set(VRIntroLib_SOURCES
   VRIntroApp.cpp
   VRIntroApp.h
@@ -62,6 +60,7 @@ if(NOT SHOW_CONSOLE AND ${CMAKE_CXX_COMPILER_ID} STREQUAL "MSVC")
 endif()
 
 add_library(VRIntroLib STATIC ${VRIntroLib_SOURCES})
+
 target_link_components(VRIntroLib Application GLController GLShaderLoader GLTexture2Loader Primitives SDLController OculusVR)
 target_package(VRIntroLib Eigen)
 


### PR DESCRIPTION
...lpful for third party dev)

I had to move the inclusion of Common.cmake one level lower to propagate the EXTERNAL_LIBRARY_DIR in time for find_package(Components REQUIRED). Since we are working under assumption that  ALL external libs are in one place we should not impose third party developers to edit Components_DIR manually but rather let cmake configuration do the job. This approach also gets rid of erroneous messages that a developer does not need to be aware at a time of initial build (speaking of Components_DIR_NOTFOUND errors) and thus simplifies his/hers overall experience.   
